### PR TITLE
Minor change to homepage contribution ref

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,4 @@ For an overview of the OpenDI project as a whole, see the [OpenDI Intro](./OpenD
 
 ## Contribution
 
-Contribution guide will go here. Maybe!
+For information on how you can contribute to OpenDI, see the [contribution guide](./How%20To%20Contribute.md).


### PR DESCRIPTION
Updated the homepage's placeholder reference to contribution guide with a more accurate one. This is mostly to test the merge-related Action changes.