### PR TITLE
Placeholders and minor changes from OpenDI mtg

### DIFF
--- a/docs/API Specification.md
+++ b/docs/API Specification.md
@@ -1,0 +1,7 @@
+# Watch this space
+This content is planned or under development, but is not yet ready for public comment.  
+Keep an eye on [the OpenDI Discord Server](https://discord.gg/FtAX3JStJz) for announcements related to this content.
+
+# What will this be?
+
+The OpenDI API Specification will define API endpoints that all OpenDI-compliant systems are expected to handle.

--- a/docs/How-to-use-OpenDI/Asset Guide.md
+++ b/docs/How-to-use-OpenDI/Asset Guide.md
@@ -1,0 +1,7 @@
+# Watch this space
+This content is planned or under development, but is not yet ready for public comment.  
+Keep an eye on [the OpenDI Discord Server](https://discord.gg/FtAX3JStJz) for announcements related to this content.
+
+# What will this be?
+
+The asset guide will describe all the assets comprising the OpenDI standards at a high level, and provide guidance about how to use them.

--- a/docs/How-to-use-OpenDI/Gallery.md
+++ b/docs/How-to-use-OpenDI/Gallery.md
@@ -1,0 +1,8 @@
+# Watch this space
+This content is planned or under development, but is not yet ready for public comment.  
+Keep an eye on [the OpenDI Discord Server](https://discord.gg/FtAX3JStJz) for announcements related to this content.
+
+# What will this be?
+
+The gallery will display projects, resources, tools, etc. that OpenDI community members have made conforming to the OpenDI standards.  
+Expect the gallery to grow over time!

--- a/docs/How-to-use-OpenDI/Reference Implementations.md
+++ b/docs/How-to-use-OpenDI/Reference Implementations.md
@@ -1,0 +1,7 @@
+# Watch this space
+This content is planned or under development, but is not yet ready for public comment.  
+Keep an eye on [the OpenDI Discord Server](https://discord.gg/FtAX3JStJz) for announcements related to this content.
+
+# What will this be?
+
+Similar to the [Gallery](./How-to-use-OpenDI/Gallery.md), reference implementations will demonstrate OpenDI compliance with complete example projects.

--- a/docs/_Coming Soon template.md
+++ b/docs/_Coming Soon template.md
@@ -1,0 +1,7 @@
+# Watch this space
+This content is planned or under development, but is not yet ready for public comment.  
+Keep an eye on [the OpenDI Discord Server](https://discord.gg/FtAX3JStJz) for announcements related to this content.
+
+# What will this be?
+
+[Describe the forthcoming content here.]

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,13 @@ This is a placeholder for our landing page.
 
 For an overview of the OpenDI project as a whole, see the [OpenDI Intro](./OpenDI%20Intro%20Material.md).
 
-## OpenDI Material
+## OpenDI Standards
 
 ### [Roles and User Stories](https://iamkeldev.github.io/draft-opendi-roles-user-stories)
 
 ### [JSON Schema Specification](https://iamkeldev.github.io/draft-opendi-json-schema)
+
+### [API Specification](./API%20Specification.md)
 
 ## Contribution
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,11 +10,16 @@ docs_dir: "docs"  #Local directory for docs .md files
 nav:
   - Home: index.md
   - 'Overview': 'OpenDI Intro Material.md'
-  - 'OpenDI Materials':
+  - 'How to Contribute': 'How To Contribute.md'
+  - 'OpenDI Standards':
     - 'Roles and User Stories': https://iamkeldev.github.io/draft-opendi-roles-user-stories
     - 'JSON Schema Specification': https://iamkeldev.github.io/draft-opendi-json-schema
+    - 'API Specification': 'API Specification.md'
+  - 'How to use OpenDI':
+    - 'Asset Guide': './How-to-use-OpenDI/Asset Guide.md'
+    - 'Reference Implementations': './How-to-use-OpenDI/Reference Implementations.md'
+    - 'Gallery': './How-to-use-OpenDI/Gallery.md'
   - 'OpenDI Glossary': 'OpenDI Glossary.md'
-  - 'How to Contribute': 'How To Contribute.md'
 
 # Exclude _Role Page Template.md
 exclude_docs: |


### PR DESCRIPTION
Added:
- Template for missing but planned content, to fill out the structure of the site
- Placeholders for planned content: - API Specification - Asset Guide - Gallery - Reference Implementations

Updated mkdocs config:
- Added placeholders
- Reordered contribution guide